### PR TITLE
Added 'extern "C" { ... }' to the header files to force C linkage.

### DIFF
--- a/src/ottery.h
+++ b/src/ottery.h
@@ -15,6 +15,11 @@
 #define OTTERY_H_HEADER_INCLUDED_
 #include <stdint.h>
 #include <sys/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "ottery_common.h"
 
 /** @file */
@@ -130,5 +135,9 @@ void ottery_wipe(void);
  * implicitly "stirred" every 1k or so.
  */
 void ottery_prevent_backtracking(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/ottery_nolock.h
+++ b/src/ottery_nolock.h
@@ -15,6 +15,11 @@
 #define OTTERY_NOLOCK_H_HEADER_INCLUDED_
 #include <stdint.h>
 #include <sys/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "ottery_common.h"
 
 /** @file */
@@ -177,5 +182,9 @@ unsigned ottery_st_rand_range_nolock(struct ottery_state_nolock *st, unsigned to
  *   chosen uniformly.
  */
 uint64_t ottery_st_rand_range64_nolock(struct ottery_state_nolock *st, uint64_t top);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/ottery_st.h
+++ b/src/ottery_st.h
@@ -15,6 +15,11 @@
 #define OTTERY_ST_H_HEADER_INCLUDED_
 #include <stdint.h>
 #include <sys/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "ottery_common.h"
 
 /** @file */
@@ -171,5 +176,9 @@ unsigned ottery_st_rand_range(struct ottery_state *st, unsigned top);
  *   chosen uniformly.
  */
 uint64_t ottery_st_rand_range64(struct ottery_state *st, uint64_t top);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif


### PR DESCRIPTION
I assume the only files users should directly be including are:
- ottery.h
- ottery_nolock.h
- ottery_st.h

ottery_version.h does not have function definitions so linkage doesn't matter, and ottery_common.h is covered because linkage is specified before it is included from the 3 header files.
